### PR TITLE
Adding notebook to update existing comments.csv file

### DIFF
--- a/update-comments-with-api.ipynb
+++ b/update-comments-with-api.ipynb
@@ -1,0 +1,175 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "import json\n",
+    "import csv\n",
+    "import pandas as pd\n",
+    "import sys\n",
+    "#This may need to be pathlib under python 3\n",
+    "import pathlib2  \n",
+    "\n",
+    "YOUR_API_KEY = '[PUT YOUR API KEY HERE]'\n",
+    "\n",
+    "API_KEY = os.getenv('API_KEY', YOUR_API_KEY)\n",
+    "\n",
+    "# progress bar\n",
+    "\n",
+    "def progress(count, total, status=''):\n",
+    "    bar_len = 35\n",
+    "    filled_len = int(round(bar_len * count / float(total)))\n",
+    "\n",
+    "    percents = round(100.0 * count / float(total), 1)\n",
+    "    bar = '=' * filled_len + '-' * (bar_len - filled_len)\n",
+    "\n",
+    "    sys.stdout.write('[%s] %s%s %s %s-%s\\r' % (bar, percents, '%', status, count, (count + 999)))\n",
+    "\n",
+    "    sys.stdout.flush() "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "doc_count_url = 'https://api.data.gov:443/regulations/v3/documents.json?api_key=%s&countsOnly=1&dct=PS&dktid=DOI-2017-0002' % API_KEY\n",
+    "r = requests.get(doc_count_url)\n",
+    "if r.status_code == 200:\n",
+    "    result = r.json()\n",
+    "    records = result['totalNumRecords']\n",
+    "    print 'Records available: {}'.format(records)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# get the previous comments\n",
+    "offset = 0\n",
+    "comments = 'dataset/comments.csv'\n",
+    "\n",
+    "#if comments.csv exists, count rows\n",
+    "from pathlib2 import Path\n",
+    "my_file = Path(comments)\n",
+    "if my_file.is_file():\n",
+    "    df = pd.read_csv(comments)\n",
+    "    offset = df.shape[0]\n",
+    "    \n",
+    "print 'Starting with comment: {}'.format(offset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "documents_url = 'https://api.data.gov:443/regulations/v3/documents.json?api_key=%s&dct=PS&dktid=DOI-2017-0002&rpp=1000&po=%s&sb=docId&so=ASC'\n",
+    "documents = list()\n",
+    "\n",
+    "#add a check to avoid API overload. Don't download more than 1 million (1000 API calls) in an hour.\n",
+    "if records - offset > 1000000:\n",
+    "    records = 900000\n",
+    "    print '*****HEADS UP!*****'\n",
+    "    print 'Only downloading a partial set of comments.'\n",
+    "    print 'This will stop after 990,000 to avoid the API limit.'\n",
+    "    print 'Run this again in an hour to get the rest.'\n",
+    "    print '*****HEADS UP!*****'\n",
+    "\n",
+    "while offset < records :\n",
+    "    progress(offset, records, status='Downloading comments')\n",
+    "    r = requests.get(documents_url % (API_KEY, offset))\n",
+    "    if r.status_code == 200:\n",
+    "        result = r.json()\n",
+    "        documents = documents + result['documents']\n",
+    "        offset += 1000\n",
+    "    else:\n",
+    "        raise Exception(\"non 200 response code\").with_traceback(tracebackobj)\n",
+    "\n",
+    "progress(records, records, status='Downloading comments')\n",
+    "print '\\n\\nDone!'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "field_names = ['documentId', 'postedDate', 'attachmentCount', 'commentText']\n",
+    "\n",
+    "# write headers if this is a new file\n",
+    "if not my_file.is_file():\n",
+    "    with open(comments, 'w') as f:\n",
+    "        writer = csv.DictWriter(f, field_names, extrasaction='ignore')\n",
+    "        writer.writeheader()\n",
+    "\n",
+    "with open(comments, 'a') as f:\n",
+    "    writer = csv.DictWriter(f, field_names, extrasaction='ignore')\n",
+    "    writer.writerows(documents)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#reality check\n",
+    "df = pd.read_csv(comments)\n",
+    "print 'Rows in comments.csv: {}'.format(df.shape[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This way you don't have to download everything from scratch. (Although it will download everything from scratch if you haven't downloaded any comments before.)

There may be one library (pathlib2) that needs to just be pathlib in Python 3. It also uses Pandas to count rows, since regular row counts don't work correctly on csv files that contain newlines inside fields. So we make a dataframe and use .shape to count rows.

Also, it adds a sanity check for when the comment count goes over 1 million. In that case, it downloads 990,000 comments and warns you to come back in an hour to run the notebook again.